### PR TITLE
Fixing the FluentSample App

### DIFF
--- a/samples/FluentSample/package-lock.json
+++ b/samples/FluentSample/package-lock.json
@@ -2643,11 +2643,13 @@
       }
     },
     "node_modules/@microsoft/power-apps": {
-      "name": "@pa-client/power-code-sdk",
-      "version": "0.0.1",
-      "resolved": "https://github.com/microsoft/PowerAppsCodeApps/releases/download/v0.0.4/7-31-pa-client-power-code-sdk-0.0.1.tgz",
-      "integrity": "sha512-+jdD0rT8sCpmkeCJlJibMm85Ly05gPhU+EPXsfbcjE5Gezq2OkRA1cxTI171FREAbnPwxcXJrMeI92dY2G6/vw==",
-      "license": "UNLICENSED"
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@microsoft/power-apps/-/power-apps-0.3.12.tgz",
+      "integrity": "sha512-BDgj8c1QPdIjkL7yf/CWmpYu0nTMtoLNze47R8wF3jJQOodZFENDj1zSyisoHvOcgyPJ9DvnhkU1dUJjMUushw==",
+      "license": "See license in LICENSE file",
+      "bin": {
+        "power-apps": "lib/cli/power-apps.js"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/samples/FluentSample/src/components/Layout.tsx
+++ b/samples/FluentSample/src/components/Layout.tsx
@@ -420,7 +420,7 @@ export default function Layout({ children }: LayoutProps) {
         {/* Center Section: App Title with Logo */}
         <div className={styles.headerCenter}>
           <img 
-            src="/PowerApps_scalable.svg" 
+            src="./PowerApps_scalable.svg" 
             alt="Power Apps" 
             style={{ 
               width: '24px', 

--- a/samples/FluentSample/src/components/ThemedApp.tsx
+++ b/samples/FluentSample/src/components/ThemedApp.tsx
@@ -1,6 +1,6 @@
 import { FluentProvider } from '@fluentui/react-components';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import { useTheme } from '../hooks/useTheme';
 import { queryClient } from '../main';
 import App from '../App';
@@ -10,10 +10,10 @@ export const ThemedApp = () => {
   
   return (
     <FluentProvider theme={theme}>
-      <QueryClientProvider client={queryClient}>
-        <BrowserRouter>
+      <QueryClientProvider client={queryClient}> 
+        <HashRouter>
           <App />
-        </BrowserRouter>
+        </HashRouter>
       </QueryClientProvider>
     </FluentProvider>
   );

--- a/samples/FluentSample/vite.config.ts
+++ b/samples/FluentSample/vite.config.ts
@@ -17,9 +17,8 @@ export default defineConfig({
           // Split vendor libraries into separate chunks
           'react-vendor': ['react', 'react-dom'],
           'router-vendor': ['react-router-dom'],
-          'fluent-components': ['@fluentui/react-components'],
-          'fluent-icons': ['@fluentui/react-icons'],
-          'fluent-tokens': ['@fluentui/tokens'],
+          // Combine Fluent UI packages to avoid circular dependencies
+          'fluent-ui': ['@fluentui/react-components', '@fluentui/react-icons', '@fluentui/tokens'],
         }
       }
     }


### PR DESCRIPTION
This PR fixes the fluent sample app, which has a Vite build issue that caused the timeout screen. 

This also takes care of the following
- Fixes the logo in the header
- Changes to the preferred HashRouter so the app correctly lands on the home page