### PR TITLE
Remove "preview" from repository README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 🚀 Power Apps code apps (preview) 
+# 🚀 Power Apps code apps
 
-Code apps are available in preview. Documentation is available on [learn.microsoft.com](https://learn.microsoft.com/en-us/power-apps/developer/code-apps/). This repo contains source for code app examples. 
+Code apps documentation is available on [learn.microsoft.com](https://learn.microsoft.com/en-us/power-apps/developer/code-apps/). This repo contains source for code app examples. 
 
 # 📄 License 
 


### PR DESCRIPTION
Removed the word 'preview' from the title and updated the first paragraph. Code Apps are now in GA!