### PR TITLE
fix(plugin): add pac 2.3.2 version check and improve auth error handling

### DIFF
--- a/plugin/power-apps-plugin/agents/code-app-architect.md
+++ b/plugin/power-apps-plugin/agents/code-app-architect.md
@@ -37,14 +37,15 @@ When consulted, you provide guidance on:
 Verify prerequisites before proceeding with any implementation work:
 
 ```bash
-node --version                         # Must be v22+
-pwsh -NoProfile -Command "pac"         # Windows executable — must use pwsh
+node --version                              # Must be v22+
+pwsh -NoProfile -Command "pac"              # Windows executable — must use pwsh; also check Version: line in output — must NOT be 2.3.2
 ```
 
 - **Node.js below v22**: Report "Node.js 22+ is required. Upgrade or switch with `nvm use 22`." and STOP.
 - **Missing @microsoft/power-apps-cli**: Report "Install with `npm install -g @microsoft/power-apps-cli`." and STOP.
 - **Missing pac**: Report "Install Power Platform CLI from https://aka.ms/PowerAppsCLI." and STOP.
-- **All present**: Report versions and proceed.
+- **pac version is 2.3.2**: This version has a known bug (`TypeError: Cannot read properties of undefined (reading 'httpClient')`) that causes `pac code push` to fail. Try upgrading: `npm install -g @microsoft/power-apps-cli`. If the upgraded version is still 2.3.2, install the known-good fallback instead: `npm install -g @microsoft/power-apps-cli@2.2.1`. Confirm user approval before any global install per shared instructions.
+- **All present and not 2.3.2**: Report versions and proceed.
 
 ## Key Considerations for Power Apps Code Apps
 

--- a/plugin/power-apps-plugin/shared/shared-instructions.md
+++ b/plugin/power-apps-plugin/shared/shared-instructions.md
@@ -117,6 +117,36 @@ When selecting an environment, use this priority order: `power.config.json` → 
 
 ---
 
+## pac Version Check
+
+**pac version 2.3.2 has a known bug where `pac code push` fails with `TypeError: Cannot read properties of undefined (reading 'httpClient')`. Never use this version.**
+
+After confirming `pac` is installed, always check its version. `pac --version` is not a valid flag, but running `pac` with no arguments prints the version in the output header:
+
+```bash
+pwsh -NoProfile -Command "pac"
+```
+
+Look for the `Version:` line in the output (e.g., `Version: 2.3.2+...`).
+
+### If version is 2.3.2:
+
+1. **Try upgrading first** (ask user confirmation per global install rule):
+   ```bash
+   npm install -g @microsoft/power-apps-cli
+   ```
+2. **Verify the upgrade** by re-running `pwsh -NoProfile -Command "pac"` and checking the `Version:` line.
+3. **If still on 2.3.2** (it is the latest available), install the known-good older version instead:
+   ```bash
+   npm install -g @microsoft/power-apps-cli@2.2.1
+   ```
+
+### If version is anything other than 2.3.2:
+
+Proceed normally — no action needed.
+
+---
+
 ## Windows CLI Compatibility
 
 The shell running Bash tool commands is bash on Windows. The `pac` CLI is a Windows executable and is **not** on the bash PATH.

--- a/plugin/power-apps-plugin/skills/create-power-app/SKILL.md
+++ b/plugin/power-apps-plugin/skills/create-power-app/SKILL.md
@@ -39,14 +39,15 @@ git --version                          # Optional but recommended
 Check `pac` CLI via PowerShell — it's a Windows executable not on the bash PATH:
 
 ```bash
-pwsh -NoProfile -Command "pac"  # Used for auth, env selection, code commands
+pwsh -NoProfile -Command "pac"             # Used for auth, env selection, code commands; also check Version: line in output — must NOT be 2.3.2
 ```
 
 - **Missing Node.js**: Report "Install Node.js v22+ from https://nodejs.org/" and STOP.
 - **Node.js below v22**: Report "Node.js 22+ is required. Please upgrade or switch with `nvm use 22`." and STOP.
 - **Missing pac**: Report "Install Power Platform CLI from https://aka.ms/PowerAppsCLI" and STOP.
 - **Missing Git**: Report "Recommended but optional." Continue if approved.
-- **All present**: Report versions and proceed.
+- **pac version is 2.3.2**: This version has a known bug (`TypeError: Cannot read properties of undefined (reading 'httpClient')`) that causes `pac code push` to fail. Try upgrading: `npm install -g @microsoft/power-apps-cli`. If the upgraded version is still 2.3.2, install the known-good fallback instead: `npm install -g @microsoft/power-apps-cli@2.2.1`. Confirm user approval before any global install per shared instructions. STOP until resolved.
+- **All present and not 2.3.2**: Report versions and proceed.
 
 
 ### Step 2: Gather Requirements

--- a/plugin/power-apps-plugin/skills/create-power-app/references/prerequisites-reference.md
+++ b/plugin/power-apps-plugin/skills/create-power-app/references/prerequisites-reference.md
@@ -5,7 +5,7 @@
 | Tool           | Minimum Version | Check Command                    | Install                     |
 | -------------- | --------------- | -------------------------------- | --------------------------- |
 | Node.js        | **v22+**        | `node --version`                 | https://nodejs.org/         |
-| pac CLI        | **latest**        | `pwsh -NoProfile -Command "pac"` | https://aka.ms/PowerAppsCLI |
+| pac CLI        | **latest, not 2.3.2** | `pwsh -NoProfile -Command "pac"` (check `Version:` line) | https://aka.ms/PowerAppsCLI |
 | Git (optional) | Any               | `git --version`                  | https://git-scm.com/        |
 
 ```bash

--- a/plugin/power-apps-plugin/skills/create-power-app/references/troubleshooting.md
+++ b/plugin/power-apps-plugin/skills/create-power-app/references/troubleshooting.md
@@ -14,7 +14,7 @@
 | ----------------------- | ------------------------------------------------------------------ |
 | Build fails             | Check Node.js LTS version, run `npm install`                       |
 | Build fails with TS6133 | Unused imports cause errors in strict mode. Remove unused imports. |
-| Auth error              | Run `pwsh -NoProfile -Command "pac auth clear" && pwsh -NoProfile -Command "pac auth create"`        |
+| Auth error              | Run `pwsh -NoProfile -Command "pac auth list"` to check auth state. If authenticated but wrong environment, run `pwsh -NoProfile -Command "pac env select --environment <id>"`. Only if that fails, run `pwsh -NoProfile -Command "pac auth create"`. |
 | No data                 | Verify user has read access to table, check browser console        |
 | Local testing           | Use same browser profile as Power Platform auth                    |
 
@@ -22,10 +22,11 @@
 
 | Error                               | Fix                                                                                                                                                                                                     |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "environment config does not match" | Ask the user: **retarget the app** (update `environmentId` in `power.config.json` to match active env) or **switch auth** (run `pwsh -NoProfile -Command "pac auth create"` to match the app's environment). Then retry. |
+| "environment config does not match" | Run `pwsh -NoProfile -Command "pac auth list"` to check active environment. Then either: **re-target the app** (update `environmentId` in `power.config.json` to match active env), or **switch environment** (`pwsh -NoProfile -Command "pac env select --environment <id>"`). Only if switching environment fails, run `pwsh -NoProfile -Command "pac auth create"`. |
 | DNS/network error                   | Try different environment or contact admin.                                                                                                                                                             |
 | Auth error                          | Run `pwsh -NoProfile -Command "pac auth create"` and retry.                                                                                                                                                              |
 | Auth error on macOS (pac bug)       | `pac` has known auth bugs on Mac. Use the npx CLI instead: run `npm install -g @microsoft/power-apps-cli` (skip if already installed), then `npx power-apps push`. |
+| `TypeError: Cannot read properties of undefined (reading 'httpClient')` | Caused by pac version 2.3.2. Try upgrading: `npm install -g @microsoft/power-apps-cli`. If the version is still 2.3.2, install the known-good fallback: `npm install -g @microsoft/power-apps-cli@2.2.1`. |
 
 ## Resources
 

--- a/plugin/power-apps-plugin/skills/deploy/SKILL.md
+++ b/plugin/power-apps-plugin/skills/deploy/SKILL.md
@@ -43,10 +43,22 @@ pac code push
 
 Capture the app URL from the output if present.
 
-If deploy fails, report the error and stop — do not retry silently. Common fixes are in the troubleshooting guide:
+If deploy fails, report the error and follow this diagnostic sequence — do not retry silently:
 
-- Auth error → `pwsh -NoProfile -Command "pac auth create"`
-- Environment mismatch → `pwsh -NoProfile -Command "pac env select --environment <id>"`
+1. **Always run `pac auth list` first** to check authentication state and which environment is active:
+   ```bash
+   pwsh -NoProfile -Command "pac auth list"
+   ```
+2. **If authenticated but targeting the wrong environment**: switch environment and retry:
+   ```bash
+   pwsh -NoProfile -Command "pac env select --environment <correct-environment-id>"
+   pwsh -NoProfile -Command "pac code push"
+   ```
+3. **If `pac env select` fails, or pac is not authenticated at all**: then run:
+   ```bash
+   pwsh -NoProfile -Command "pac auth create"
+   pwsh -NoProfile -Command "pac code push"
+   ```
 
 **Mac fallback — if `pac code push` fails with an auth error on macOS:**
 `pac` has known authentication bugs on Mac that can block the push. Use the npx CLI instead:


### PR DESCRIPTION
- Block pac version 2.3.2 across all prerequisite checks due to known bug where pac code push fails with TypeError: Cannot read properties of undefined (reading 'httpClient'); instruct upgrade or fallback to 2.2.1
- Fix pac version check command: pac --version is not a valid flag; use plain pac and read Version: line from output header
- Update deploy failure flow to always run pac auth list first, then pac env select before falling back to pac auth create