### PR TITLE
fix(plugin): correct pac CLI version management commands

### DIFF
--- a/plugin/power-apps-plugin/agents/code-app-architect.md
+++ b/plugin/power-apps-plugin/agents/code-app-architect.md
@@ -44,7 +44,7 @@ pwsh -NoProfile -Command "pac"              # Windows executable — must use pw
 - **Node.js below v22**: Report "Node.js 22+ is required. Upgrade or switch with `nvm use 22`." and STOP.
 - **Missing @microsoft/power-apps-cli**: Report "Install with `npm install -g @microsoft/power-apps-cli`." and STOP.
 - **Missing pac**: Report "Install Power Platform CLI from https://aka.ms/PowerAppsCLI." and STOP.
-- **pac version is 2.3.2**: This version has a known bug (`TypeError: Cannot read properties of undefined (reading 'httpClient')`) that causes `pac code push` to fail. Try upgrading: `npm install -g @microsoft/power-apps-cli`. If the upgraded version is still 2.3.2, install the known-good fallback instead: `npm install -g @microsoft/power-apps-cli@2.2.1`. Confirm user approval before any global install per shared instructions.
+- **pac version is 2.3.2**: This version has a known bug (`TypeError: Cannot read properties of undefined (reading 'httpClient')`) that causes `pac code push` to fail. Try upgrading: `dotnet tool update -g Microsoft.PowerApps.CLI.Tool`. If the upgraded version is still 2.3.2, downgrade by uninstalling first then installing 2.2.1: `dotnet tool uninstall -g Microsoft.PowerApps.CLI.Tool` then `dotnet tool install -g Microsoft.PowerApps.CLI.Tool --version 2.2.1`. Confirm user approval before any global install per shared instructions.
 - **All present and not 2.3.2**: Report versions and proceed.
 
 ## Key Considerations for Power Apps Code Apps

--- a/plugin/power-apps-plugin/shared/shared-instructions.md
+++ b/plugin/power-apps-plugin/shared/shared-instructions.md
@@ -133,12 +133,13 @@ Look for the `Version:` line in the output (e.g., `Version: 2.3.2+...`).
 
 1. **Try upgrading first** (ask user confirmation per global install rule):
    ```bash
-   npm install -g @microsoft/power-apps-cli
+   pwsh -NoProfile -Command "dotnet tool update -g Microsoft.PowerApps.CLI.Tool"
    ```
 2. **Verify the upgrade** by re-running `pwsh -NoProfile -Command "pac"` and checking the `Version:` line.
-3. **If still on 2.3.2** (it is the latest available), install the known-good older version instead:
+3. **If still on 2.3.2** (it is the latest available), downgrade to the known-good version. `dotnet tool install` cannot downgrade — uninstall first, then install:
    ```bash
-   npm install -g @microsoft/power-apps-cli@2.2.1
+   pwsh -NoProfile -Command "dotnet tool uninstall -g Microsoft.PowerApps.CLI.Tool"
+   pwsh -NoProfile -Command "dotnet tool install -g Microsoft.PowerApps.CLI.Tool --version 2.2.1"
    ```
 
 ### If version is anything other than 2.3.2:

--- a/plugin/power-apps-plugin/skills/create-power-app/SKILL.md
+++ b/plugin/power-apps-plugin/skills/create-power-app/SKILL.md
@@ -46,7 +46,7 @@ pwsh -NoProfile -Command "pac"             # Used for auth, env selection, code 
 - **Node.js below v22**: Report "Node.js 22+ is required. Please upgrade or switch with `nvm use 22`." and STOP.
 - **Missing pac**: Report "Install Power Platform CLI from https://aka.ms/PowerAppsCLI" and STOP.
 - **Missing Git**: Report "Recommended but optional." Continue if approved.
-- **pac version is 2.3.2**: This version has a known bug (`TypeError: Cannot read properties of undefined (reading 'httpClient')`) that causes `pac code push` to fail. Try upgrading: `npm install -g @microsoft/power-apps-cli`. If the upgraded version is still 2.3.2, install the known-good fallback instead: `npm install -g @microsoft/power-apps-cli@2.2.1`. Confirm user approval before any global install per shared instructions. STOP until resolved.
+- **pac version is 2.3.2**: This version has a known bug (`TypeError: Cannot read properties of undefined (reading 'httpClient')`) that causes `pac code push` to fail. Try upgrading: `dotnet tool update -g Microsoft.PowerApps.CLI.Tool`. If the upgraded version is still 2.3.2, downgrade by uninstalling first then installing 2.2.1: `dotnet tool uninstall -g Microsoft.PowerApps.CLI.Tool` then `dotnet tool install -g Microsoft.PowerApps.CLI.Tool --version 2.2.1`. Confirm user approval before any global install per shared instructions. STOP until resolved.
 - **All present and not 2.3.2**: Report versions and proceed.
 
 

--- a/plugin/power-apps-plugin/skills/create-power-app/references/troubleshooting.md
+++ b/plugin/power-apps-plugin/skills/create-power-app/references/troubleshooting.md
@@ -26,7 +26,7 @@
 | DNS/network error                   | Try different environment or contact admin.                                                                                                                                                             |
 | Auth error                          | Run `pwsh -NoProfile -Command "pac auth create"` and retry.                                                                                                                                                              |
 | Auth error on macOS (pac bug)       | `pac` has known auth bugs on Mac. Use the npx CLI instead: run `npm install -g @microsoft/power-apps-cli` (skip if already installed), then `npx power-apps push`. |
-| `TypeError: Cannot read properties of undefined (reading 'httpClient')` | Caused by pac version 2.3.2. Try upgrading: `npm install -g @microsoft/power-apps-cli`. If the version is still 2.3.2, install the known-good fallback: `npm install -g @microsoft/power-apps-cli@2.2.1`. |
+| `TypeError: Cannot read properties of undefined (reading 'httpClient')` | Caused by pac version 2.3.2. Try upgrading: `dotnet tool update -g Microsoft.PowerApps.CLI.Tool`. If the version is still 2.3.2, downgrade: `dotnet tool uninstall -g Microsoft.PowerApps.CLI.Tool` then `dotnet tool install -g Microsoft.PowerApps.CLI.Tool --version 2.2.1`. |
 
 ## Resources
 


### PR DESCRIPTION
Use dotnet tool commands instead of npm for pac CLI version management. dotnet tool install cannot downgrade, so uninstall first when rolling back to 2.2.1.