### PR TITLE
fix(codegen): remove upload() from image-only entities and fix Edm.Guid OData serialization

### DIFF
--- a/samples/Dataverse/src/generated/services/SystemusersService.ts
+++ b/samples/Dataverse/src/generated/services/SystemusersService.ts
@@ -70,19 +70,6 @@ export class SystemusersService {
     });
   }
 
-  public static async upload(id: string, columnName: SystemusersUploadColumnName, file: File, fileDisplayName?: string): Promise<IOperationResult<void>> {
-    const arrayBuffer = await file.arrayBuffer();
-    const data = new Uint8Array(arrayBuffer);
-    const result = await SystemusersService.client.uploadFileToRecord(
-      SystemusersService.dataSourceName,
-      id,
-      columnName,
-      fileDisplayName || file.name,
-      data,
-    );
-    return result;
-  }
-
   public static async downloadImage(id: string, columnName: SystemusersImageColumnName, fullSize: boolean = false): Promise<IOperationResult<Uint8Array>> {
     const result = await SystemusersService.client.downloadImageFromRecord(
       SystemusersService.dataSourceName,


### PR DESCRIPTION
## Summary

Fixes two related codegen bugs in the add-dataverse-api code generator.

## Bug #344 - systemuser service generates uploadFileToRecord call that doesn't exist

The SystemusersService.ts sample contained an upload() method calling uploadFileToRecord on the Dataverse client. The systemuser entity has image columns only (entityimage) with no file columns. uploadFileToRecord does not exist in @microsoft/power-apps@1.1.3 (current public release), causing TypeScript compilation errors.

Fix: Removed the upload() method from SystemusersService.ts. The downloadImage() and deleteFileOrImage() methods remain (they use downloadImageFromRecord and deleteFileOrImageFromRecord which do exist).

The root codegen fix (changing hasFileOrImageColumns to hasFileColumns for upload() generation) is in the internal monorepo on branch fix/edm-type-codegen-344-357.

## Bug #357 - Edm.Guid params serialized as quoted strings

Dataverse function parameters typed as Edm.Guid were being serialized as OData string literals: SystemUserId='<guid>'. Dataverse requires unquoted GUID literals: SystemUserId=<guid>.

Root cause: x-ms-csdl-type was stripped in the codegen pipeline and toODataLiteral() was not aware of Edm.Guid. All fixes are in the internal monorepo.

## Changes

- samples/Dataverse/src/generated/services/SystemusersService.ts - removed upload() method

Closes #344
Closes #357